### PR TITLE
don't show class files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 *.ipr
 *.iml
 *.iws
+*.class
+


### PR DESCRIPTION
I build with geany 1.30.1 at the moment and do github from command line - this often shows created class files which I don't want to see